### PR TITLE
feat: Implement progressive loading for home screen videos

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -40,29 +40,39 @@ class _HomeScreenState extends State<HomeScreen> {
             final video = videoProvider.videos[index];
 
             return ListTile(
-              leading: CachedNetworkImage(
-                imageUrl: video.thumbnailUrl,
-                width: 80,
-                height: 50,
-                fit: BoxFit.cover,
-                placeholder: (context, url) => Shimmer.fromColors(
-                  baseColor: Colors.grey[300]!,
-                  highlightColor: Colors.grey[100]!,
-                  child: Container(
-                    width: 80,
-                    height: 50,
-                    color: Colors.white,
-                  ),
-                ),
-                errorWidget: (context, url, error) => Container(
-                  width: 80,
-                  height: 50,
-                  color: Colors.grey,
-                  child: const Icon(Icons.broken_image, color: Colors.white),
-                ),
-              ),
+              leading: (video.thumbnailUrl == null || video.thumbnailUrl!.isEmpty)
+                  ? Shimmer.fromColors( // Or your preferred placeholder if thumbnail URL is not yet available
+                      baseColor: Colors.grey[300]!,
+                      highlightColor: Colors.grey[100]!,
+                      child: Container(
+                        width: 80,
+                        height: 50,
+                        color: Colors.white,
+                      ),
+                    )
+                  : CachedNetworkImage(
+                      imageUrl: video.thumbnailUrl!, // Now we know it's not null here
+                      width: 80,
+                      height: 50,
+                      fit: BoxFit.cover,
+                      placeholder: (context, url) => Shimmer.fromColors(
+                        baseColor: Colors.grey[300]!,
+                        highlightColor: Colors.grey[100]!,
+                        child: Container(
+                          width: 80,
+                          height: 50,
+                          color: Colors.white,
+                        ),
+                      ),
+                      errorWidget: (context, url, error) => Container(
+                        width: 80,
+                        height: 50,
+                        color: Colors.grey,
+                        child: const Icon(Icons.broken_image, color: Colors.white),
+                      ),
+                    ),
               title: Text(
-                video.title,
+                video.title ?? "Loading title...", // Or handle empty string if preferred
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
               ),


### PR DESCRIPTION
This change addresses slow initial load times on the home screen by modifying how video titles and thumbnails are loaded.

Key changes:
- `VideoProvider` now populates the video list initially with placeholder data (null titles and thumbnail URLs).
- It then asynchronously fetches the actual metadata (title, thumbnail URL) for each video and updates the list, notifying listeners for each update.
- `HomeScreen` is updated to display "Loading title..." and a shimmer placeholder for thumbnails while the actual data is being fetched.

This allows the home screen to render its structure quickly, with video details appearing progressively, improving the perceived performance.

Note: Live testing of the application was hindered by a persistent error. The changes were verified through code analysis, which indicates the implementation aligns with the intended behavior.